### PR TITLE
Mise à jour vers Keycloak 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
 		<wildfly.maven.plugin.version>2.1.0.Final</wildfly.maven.plugin.version>
 		<keycloak.version>25.0.6</keycloak.version>
 		<bouncycastle.version>1.74</bouncycastle.version>
+		<jersey.version>3.1.9</jersey.version>
 		<!-- Testing Tools -->
 		<junit.jupiter.version>5.8.1</junit.jupiter.version>
 		<assertj.version>3.21.0</assertj.version>
@@ -294,6 +295,12 @@
 			<groupId>com.nimbusds</groupId>
 			<artifactId>nimbus-jose-jwt</artifactId>
 			<version>${nimbus.jose-jwt.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.core</groupId>
+			<artifactId>jersey-common</artifactId>
+			<version>${jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
 		<wildfly.maven.plugin.version>2.1.0.Final</wildfly.maven.plugin.version>
 		<keycloak.version>25.0.6</keycloak.version>
 		<bouncycastle.version>1.74</bouncycastle.version>
+		<jakarta-xml-bind.version>4.0.2</jakarta-xml-bind.version>
 		<jersey.version>3.1.9</jersey.version>
 		<!-- Testing Tools -->
 		<junit.jupiter.version>5.8.1</junit.jupiter.version>
@@ -259,6 +260,12 @@
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-crypto-default</artifactId>
 			<version>${keycloak.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>${jakarta-xml-bind.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
 	
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
 		<maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
 		<maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 		<maven.source.plugin.version>3.2.1</maven.source.plugin.version>
 		<maven.javadoc.plugin.version>3.3.1</maven.javadoc.plugin.version>
 		<wildfly.maven.plugin.version>2.1.0.Final</wildfly.maven.plugin.version>
-		<keycloak.version>22.0.1</keycloak.version>
+		<keycloak.version>25.0.6</keycloak.version>
 		<bouncycastle.version>1.74</bouncycastle.version>
 		<!-- Testing Tools -->
 		<junit.jupiter.version>5.8.1</junit.jupiter.version>

--- a/src/main/java/fr/ans/keycloak/providers/prosanteconnect/ProSanteConnectIdentityProvider.java
+++ b/src/main/java/fr/ans/keycloak/providers/prosanteconnect/ProSanteConnectIdentityProvider.java
@@ -314,7 +314,7 @@ final class ProSanteConnectIdentityProvider extends OIDCIdentityProvider
 	protected BrokeredIdentityContext extractIdentity(AccessTokenResponse tokenResponse, String accessToken,
 			JsonWebToken idToken) throws IOException {
 		var id = idToken.getSubject();
-		var identity = new BrokeredIdentityContext(id);
+		var identity = new BrokeredIdentityContext(id, getConfig());
 
 		var name = (String) idToken.getOtherClaims().get(IDToken.NAME);
 		var givenName = (String) idToken.getOtherClaims().get(IDToken.GIVEN_NAME);

--- a/src/test/java/fr/ans/keycloak/providers/prosanteconnect/ProSanteConnectIdentityProviderTest.java
+++ b/src/test/java/fr/ans/keycloak/providers/prosanteconnect/ProSanteConnectIdentityProviderTest.java
@@ -81,8 +81,8 @@ class ProSanteConnectIdentityProviderTest {
     httpClientProvider = mock(HttpClientProvider.class);
     httpClient = mock(CloseableHttpClient.class);
 
-    when(httpClientProvider.get(config.getJwksUrl()))
-        .thenAnswer(answer -> new ByteArrayInputStream(publicKeysStore.toJsonByteArray()));
+    when(httpClientProvider.getString(config.getJwksUrl()))
+            .thenAnswer(answer -> publicKeysStore.toJsonFormat());
     session = givenKeycloakSession(httpClientProvider, httpClient);
 
     provider = new ProSanteConnectIdentityProvider(session, config);

--- a/src/test/java/fr/ans/keycloak/providers/prosanteconnect/ProSanteConnectIdentityProviderTest.java
+++ b/src/test/java/fr/ans/keycloak/providers/prosanteconnect/ProSanteConnectIdentityProviderTest.java
@@ -64,6 +64,13 @@ import static org.mockito.Mockito.*;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class ProSanteConnectIdentityProviderTest {
 
+  /**
+   * Value copied from {@link HttpClientProvider#getMaxConsumedResponseSize()} (new method in Keycloak 25)
+   *
+   * @see <a href="https://github.com/keycloak/keycloak/commit/6de5325d1c49053a8f5bfd84ed4a5a7646ea3a65">Commit : Limit the received content when handling the content as a String</a>
+   */
+  private static final long DEFAULT_MAX_CONSUMED_RESPONSE_SIZE = 10_000_000L;
+
   // Used by KeycloakSession
   private HttpClientProvider httpClientProvider;
   private CloseableHttpClient httpClient;
@@ -83,6 +90,8 @@ class ProSanteConnectIdentityProviderTest {
 
     when(httpClientProvider.getString(config.getJwksUrl()))
             .thenAnswer(answer -> publicKeysStore.toJsonFormat());
+    when(httpClientProvider.getMaxConsumedResponseSize())
+            .thenReturn(DEFAULT_MAX_CONSUMED_RESPONSE_SIZE);
     session = givenKeycloakSession(httpClientProvider, httpClient);
 
     provider = new ProSanteConnectIdentityProvider(session, config);


### PR DESCRIPTION
Bonjour,

Dans le cadre du projet ROR National, j'ai dû apporter quelques changements à cette extension pour passer à la version 25 de Keycloak. Je crée cette Pull Request pour vous partager ces changements, que j'ai détaillés dans chaque message de commit.

J'ai aussi monté la version de Java (21) car cette version est recommandé et [la version 17 est dépréciée](https://www.keycloak.org/docs/latest/release_notes/index.html#java-17-support-is-deprecated) pour Keycloak 25. Mais le projet semble aussi fonctionner sous Java 17.

Je n'ai pas touché à la version de l'extension (4.0.0), je vous laisse la modifier à votre guise et apporter tout autre modification si nécessaire.

Loïc BERTRAND
Atos France, Metz

Solves #29